### PR TITLE
Revert remove prompt + expose ARN as properties for ELBs for further usage

### DIFF
--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -50,6 +50,12 @@ func (n *Nuke) Run() error {
 	if n.Parameters.Force {
 		fmt.Printf("Waiting %v before continuing.\n", forceSleep)
 		time.Sleep(forceSleep)
+	} else {
+		fmt.Printf("Do you want to continue? Enter account alias to continue.\n")
+		err = Prompt(n.Account.Alias())
+		if err != nil {
+			return err
+		}
 	}
 
 	err = n.Scan()
@@ -72,6 +78,12 @@ func (n *Nuke) Run() error {
 	if n.Parameters.Force {
 		fmt.Printf("Waiting %v before continuing.\n", forceSleep)
 		time.Sleep(forceSleep)
+	} else {
+		fmt.Printf("Do you want to continue? Enter account alias to continue.\n")
+		err = Prompt(n.Account.Alias())
+		if err != nil {
+			return err
+		}
 	}
 
 	failCount := 0

--- a/resources/elbv2-alb.go
+++ b/resources/elbv2-alb.go
@@ -120,6 +120,7 @@ func (e *ELBv2LoadBalancer) DisableProtection() error {
 
 func (e *ELBv2LoadBalancer) Properties() types.Properties {
 	properties := types.NewProperties()
+	properties.Set("ARN", e.arn)
 	for _, tagValue := range e.tags {
 		properties.SetTag(tagValue.Key, tagValue.Value)
 	}

--- a/resources/elbv2-targetgroup.go
+++ b/resources/elbv2-targetgroup.go
@@ -79,6 +79,7 @@ func (e *ELBv2TargetGroup) Remove() error {
 
 func (e *ELBv2TargetGroup) Properties() types.Properties {
 	properties := types.NewProperties()
+	properties.Set("ARN", e.arn)
 	for _, tagValue := range e.tags {
 		properties.SetTag(tagValue.Key, tagValue.Value)
 	}

--- a/resources/route53-hosted-zones.go
+++ b/resources/route53-hosted-zones.go
@@ -69,6 +69,7 @@ func (hz *Route53HostedZone) Properties() types.Properties {
 		properties.SetTag(tag.Key, tag.Value)
 	}
 	properties.Set("Name", hz.name)
+	properties.Set("ID", hz.id)
 	return properties
 }
 


### PR DESCRIPTION
1. Revert prompts as we can just use the Force parameters
2. Expose ARN in ELB (this will be upstreamed too). This will be used to be able to tag resources
3. Expose HostedZOne ID for tagging purposes